### PR TITLE
Add A4 to the prefab example

### DIFF
--- a/rules/examples/Advanced Despatch Advice use cases/AdvancedDespatchAdvice__Example_UseCase_2_ Prefab.xml
+++ b/rules/examples/Advanced Despatch Advice use cases/AdvancedDespatchAdvice__Example_UseCase_2_ Prefab.xml
@@ -110,6 +110,16 @@
             <cbc:Name>MANTUM SPECIAL AB (PAYEX)</cbc:Name>
           </cac:PartyName>
         </cac:CarrierParty>
+
+        <!-- GWP A4 value -->
+        <cac:OriginalDespatchTransportationService>
+          <cbc:TransportServiceCode>FuelReport</cbc:TransportServiceCode>
+          <cac:EnvironmentalEmission>
+              <cbc:EnvironmentalEmissionTypeCode>CO2</cbc:EnvironmentalEmissionTypeCode>
+              <cbc:ValueMeasure unitCode="KGM">1.852442</cbc:ValueMeasure>
+          </cac:EnvironmentalEmission>
+        </cac:OriginalDespatchTransportationService>
+
       </cac:Consignment>
       <cac:Delivery>
         <cac:DeliveryLocation>


### PR DESCRIPTION
This change adds GWP value A4 to the Despatch Advice example for Prefab Concrete.

